### PR TITLE
Windows でカメラがチラつく問題の解消

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -61,7 +61,7 @@ class App(ctk.CTk):
             # --- display camera frame ---
             self.delay = 40  # ms
             self.update_canvas()
-            # self.update()
+
         except BaseException as e:
             print(type(e))
             print(e)

--- a/gui.py
+++ b/gui.py
@@ -61,6 +61,7 @@ class App(ctk.CTk):
             # --- display camera frame ---
             self.delay = 5  # ms
             self.update_canvas()
+            self.update()
         except BaseException as e:
             print(type(e))
             print(e)

--- a/gui.py
+++ b/gui.py
@@ -59,9 +59,9 @@ class App(ctk.CTk):
                 )
 
             # --- display camera frame ---
-            self.delay = 5  # ms
+            self.delay = 40  # ms
             self.update_canvas()
-            self.update()
+            # self.update()
         except BaseException as e:
             print(type(e))
             print(e)


### PR DESCRIPTION
Windows でカメラがチラつく問題を解消しました。

Windows11 でいい感じの動作を確認していますが、MacOS での動作確認ができていません。MacOS でも正常に動作するようであればマージしてください。実装ロジックは概ね `threading` を使う前と同じ感じになりました。

以下、主な修正点です。
- `threading` の廃止
  - 特に必要なかったです
- `update` メソッドを `update_canvas` メソッドで代用
  - Override ではないです
- `update_canvas` メソッドのロジック修正
  - 簡単に言うと、本来 `self.after()` を使うべきところを `while True` で無理矢理回していたみたいです
- その他、一部クラス変数になっていなかったものをクラス変数にしました
  - これはカメラの問題と関係なかったかもしれません

この変更による `gui.py` 以外の変更はありません。