### PR TITLE
API キーの更新機能実装

### DIFF
--- a/src/notion.py
+++ b/src/notion.py
@@ -1,10 +1,12 @@
 # Use Notion API to create object in database.
-import requests
 import json
 import os
 
+import requests
+
 # DATABASE_ID = "068ea96919534bcf9adba807c9f75833"    # 書籍一覧
-DATABASE_ID = "3dacfb355eb34f0b9d127a988539809a"    # books in lab
+DATABASE_ID = "3dacfb355eb34f0b9d127a988539809a"  # books in lab
+
 
 def get_api_key(name: str) -> str:
     """
@@ -28,12 +30,13 @@ def get_api_key(name: str) -> str:
         os.environ[name] = api_key
         return api_key
 
+
 def get_page_ids(database_id):
     """Function to get information of current pages in database"""
     NOTION_API_KEY = get_api_key("NOTION_API_KEY")
 
     url = f"https://api.notion.com/v1/databases/{database_id}/query"
-    headers =  {
+    headers = {
         "Notion-Version": "2022-06-28",
         "Authorization": "Bearer " + NOTION_API_KEY,
         "Content-Type": "application/json",
@@ -43,15 +46,16 @@ def get_page_ids(database_id):
     with open("barcode/current_books.json", "w") as f:
         json.dump(data, f, indent=4, ensure_ascii=False)
 
+
 def add_book_info(
-        isbn: int,
-        title: str,
-        authors: list[str] | None,
-        published_date: str | None,
-        location: str,
-        description: str | None,
-        thumbnail_link: str | None
-        ):
+    isbn: int,
+    title: str,
+    authors: list[str] | None,
+    published_date: str | None,
+    location: str,
+    description: str | None,
+    thumbnail_link: str | None,
+):
     """
     Function to add book information to given database.
     `isbn` and `title` should not be `None`.
@@ -59,7 +63,7 @@ def add_book_info(
     NOTION_API_KEY = get_api_key("NOTION_API_KEY")
     url = "https://api.notion.com/v1/pages"
 
-    headers =  {
+    headers = {
         "Notion-Version": "2022-06-28",
         "Authorization": "Bearer " + NOTION_API_KEY,
         "Content-Type": "application/json",
@@ -67,48 +71,27 @@ def add_book_info(
 
     payload = {
         "parent": {"database_id": DATABASE_ID},
-        "properties": {
-            "ISBN-13": {
-                "number": isbn
-            },
-            "名前": {
-                "title": [
-                    {"text": {"content": title}}
-                ]
-            }
-        },
+        "properties": {"ISBN-13": {"number": isbn}, "名前": {"title": [{"text": {"content": title}}]}},
         "children": [
             {
                 "object": "block",
                 "type": "heading_2",
-                "heading_2": {
-                    "rich_text": [{ "type": "text", "text": { "content": "概要" } }]
-                }
+                "heading_2": {"rich_text": [{"type": "text", "text": {"content": "概要"}}]},
             },
-        ]
+        ],
     }
 
     # authors
     if authors:
-        payload["properties"]["著者"] = {
-                "multi_select": [
-                    {"name": n} for n in authors
-                ]
-            }
-    
+        payload["properties"]["著者"] = {"multi_select": [{"name": n} for n in authors]}
+
     # published date
     if published_date:
-        payload["properties"]["出版年"] = {
-                "date": {
-                    "start": published_date
-                }
-            }
+        payload["properties"]["出版年"] = {"date": {"start": published_date}}
 
     # location
     if location:
-        payload["properties"]["所蔵場所"] = {
-                "select": {"name": location}
-            }
+        payload["properties"]["所蔵場所"] = {"select": {"name": location}}
 
     # description
     if description:
@@ -116,39 +99,28 @@ def add_book_info(
             {
                 "object": "block",
                 "type": "quote",
-                "quote": {
-                    "rich_text": [
-                        {
-                            "type": "text",
-                            "text": {
-                                "content": description
-                            }
-                        }
-                    ]
-                }
+                "quote": {"rich_text": [{"type": "text", "text": {"content": description}}]},
             }
         )
 
     # thumbnail
     if thumbnail_link:
-        payload["cover"] = {
-            "type": "external",
-            "external": {"url": thumbnail_link}
-        }
+        payload["cover"] = {"type": "external", "external": {"url": thumbnail_link}}
 
     response = requests.post(url, headers=headers, json=payload)
     print(response)
 
+
 if __name__ == "__main__":
-    
+
     add_book_info(
         isbn=978_0000_0000_00,
-        title="卒業論文", 
+        title="卒業論文",
         published_date="2024-01-31",
         authors=["Naoki Shimoda", "Akihiro Yamamoto"],
         location="N1",
-        description='本研究では、説明可能な過程で多肢選択問題に対して解答する手法の開発を行う。',
-        thumbnail_link="https://thumb.ac-illust.com/7a/7aa8e40fe838b70253a97eacbcb32764_t.jpeg"
+        description="本研究では、説明可能な過程で多肢選択問題に対して解答する手法の開発を行う。",
+        thumbnail_link="https://thumb.ac-illust.com/7a/7aa8e40fe838b70253a97eacbcb32764_t.jpeg",
     )
 
     # get_page_ids(DATABASE_ID)

--- a/src/notion.py
+++ b/src/notion.py
@@ -23,7 +23,7 @@ def get_api_key(name: str) -> str:
     api_key: str
     """
     api_key = os.environ.get(name)
-    if api_key:
+    if api_key is not None:
         return api_key
     else:
         api_key = input("Enter Notion API key: ")
@@ -55,7 +55,7 @@ def add_book_info(
     location: str,
     description: str | None,
     thumbnail_link: str | None,
-):
+) -> requests.Response:
     """
     Function to add book information to given database.
     `isbn` and `title` should not be `None`.
@@ -109,6 +109,7 @@ def add_book_info(
 
     response = requests.post(url, headers=headers, json=payload)
     print(response)
+    return response
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
API キーが古くなったり typo があったときに更新する機能を実装しました。

流れとしては
1. ( `.env` ファイルがなければ) API キー設定ダイアログを表示
2. 本の読み込み
3. API キーが違ってリクエストが失敗した場合に API キーの更新ダイアログを表示

という感じです。また、リクエストが失敗して追加できなかった本の ISBN が history に追加される問題も解消しました。

以下、主な変更点です。
- `src/notion.py` のコード整形
- `src/notion.py` の `add_book_info` 関数の戻り値を `None` から `requests.Response` に変更
  - レスポンスのステータスコードによって挙動を変えるためです
- `src/notion.py` の `get_api_key` 関数のロジック修正
  - (やや細かいですが) 空文字列(= `""` )が API キーとして設定されている場合に、`if api_key:` は `False` になります
  - そのため、上記の場合に標準入力とダイアログの両方で入力しないといけなくなります
- `upload_book` メソッドの処理の変更
  -  `add_book_info` 関数から戻り値として `requests.Response` をもらって、ステータスコードが `200` なら `self.history` に ISBN を追加するようにしました
     - 今まではリクエストが失敗して追加できなかった本の ISBN も `self.history` に追加され、もう一度読み込みを行うと「(データベースには追加されていないのに)もうあるけど本当に追加する？」と言われるバグがありました
  - API キーの再設定に `set_api` 関数を再利用しました
    - それに伴って `set_api` 関数内の処理を少し変えています(アサーションが無くなったとか)

`gui.py` と `src/notion.py` の両方を変更しています。