### PR TITLE
カメラ選択機能の実装

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -43,7 +43,7 @@ class App(ctk.CTk):
 
             assert os.getenv("NOTION_API_KEY") is not None, "Environment variable 'NOTION_API_KEY' doesn't exist."
 
-            # list available camera(s)
+            # get available camera(s)
             self.available_cam = []
             for i in range(5):
                 try:
@@ -110,6 +110,7 @@ class App(ctk.CTk):
             state="readonly",
         )
         self.cam_cmbbox.set(f"Camera {self.available_cam[0]}")
+        self.cam_cmbbox.bind("<<ComboboxSelected>>", self.switch_source)
         self.cam_cmbbox.pack(padx=10, side="bottom")
         self.cam_label.pack(padx=10, side="bottom")
 
@@ -147,6 +148,17 @@ class App(ctk.CTk):
             self.upload_book(isbn)
 
         self.after(self.delay, self.update_canvas)
+
+    def switch_source(self):
+        video_src_str = self.cam_cmbbox.get()
+        video_src = 0
+        for c in video_src_str:
+            if c.isdigit():
+                video_src = int(c)
+                break
+        self.vcap = cv2.VideoCapture(video_src)
+        self.vwidth = self.vcap.get(cv2.CAP_PROP_FRAME_WIDTH)
+        self.vheight = self.vcap.get(cv2.CAP_PROP_FRAME_HEIGHT)
 
     def upload_book(self, isbn: int):
         """

--- a/gui.py
+++ b/gui.py
@@ -120,7 +120,7 @@ class App(ctk.CTk):
         self.cam_label.pack(padx=10, side="bottom")
 
         # right frame
-        self.canvas = ctk.CTkCanvas(self.cam_frame)
+        self.canvas = ctk.CTkCanvas(self.cam_frame, highlightthickness=0)
         self.canvas.pack(expand=True, fill="both")
 
     def update_canvas(self):

--- a/gui.py
+++ b/gui.py
@@ -1,4 +1,6 @@
 import os
+
+os.environ["OPENCV_VIDEOIO_MSMF_ENABLE_HW_TRANSFORMS"] = "0"
 from tkinter import messagebox, simpledialog
 
 import customtkinter as ctk
@@ -47,12 +49,15 @@ class App(ctk.CTk):
             self.available_cam = []
             for i in range(5):
                 try:
+                    print(f"Checking camera {i} is available...")
                     cap = cv2.VideoCapture(i)
                     if cap is None or not cap.isOpened():
                         raise IndexError("Camera index out of range.")
                     else:
                         self.available_cam.append(i)
+                    cap.release()
                 except IndexError:
+                    cap.release()
                     break
             assert len(self.available_cam) != 0, "No video source detected."
 
@@ -108,9 +113,9 @@ class App(ctk.CTk):
             values=list(map("Camera {}".format, self.available_cam)),
             text_color="orange",
             state="readonly",
+            command=self.switch_source,
         )
         self.cam_cmbbox.set(f"Camera {self.available_cam[0]}")
-        self.cam_cmbbox.bind("<<ComboboxSelected>>", self.switch_source)
         self.cam_cmbbox.pack(padx=10, side="bottom")
         self.cam_label.pack(padx=10, side="bottom")
 
@@ -149,13 +154,13 @@ class App(ctk.CTk):
 
         self.after(self.delay, self.update_canvas)
 
-    def switch_source(self):
-        video_src_str = self.cam_cmbbox.get()
+    def switch_source(self, value: str):
         video_src = 0
-        for c in video_src_str:
+        for c in value:
             if c.isdigit():
                 video_src = int(c)
                 break
+        self.vcap.release()
         self.vcap = cv2.VideoCapture(video_src)
         self.vwidth = self.vcap.get(cv2.CAP_PROP_FRAME_WIDTH)
         self.vheight = self.vcap.get(cv2.CAP_PROP_FRAME_HEIGHT)

--- a/gui.py
+++ b/gui.py
@@ -43,8 +43,21 @@ class App(ctk.CTk):
 
             assert os.getenv("NOTION_API_KEY") is not None, "Environment variable 'NOTION_API_KEY' doesn't exist."
 
+            # list available camera(s)
+            self.available_cam = []
+            for i in range(5):
+                try:
+                    cap = cv2.VideoCapture(i)
+                    if cap is None or not cap.isOpened():
+                        raise IndexError("Camera index out of range.")
+                    else:
+                        self.available_cam.append(i)
+                except IndexError:
+                    break
+            assert len(self.available_cam) != 0, "No video source detected."
+
             # start video capturing
-            self.vcap = cv2.VideoCapture(0)
+            self.vcap = cv2.VideoCapture(self.available_cam[0])
             self.vwidth = self.vcap.get(cv2.CAP_PROP_FRAME_WIDTH)
             self.vheight = self.vcap.get(cv2.CAP_PROP_FRAME_HEIGHT)
 
@@ -76,7 +89,7 @@ class App(ctk.CTk):
 
     def create_widgets(self):
         """Method to create wedgets in frames"""
-        # side frame
+        # location pulldown
         self.loc_label = ctk.CTkLabel(self.side_frame, text="Location", font=ctk.CTkFont(size=16))
         self.cmbbox = ctk.CTkComboBox(
             self.side_frame,
@@ -87,6 +100,18 @@ class App(ctk.CTk):
         self.cmbbox.set("新着図書")
         self.loc_label.pack(pady=10)
         self.cmbbox.pack(padx=20)
+
+        # camera pulldown
+        self.cam_label = ctk.CTkLabel(self.side_frame, text="Camera source", font=ctk.CTkFont(size=16))
+        self.cam_cmbbox = ctk.CTkComboBox(
+            self.side_frame,
+            values=list(map("Camera {}".format, self.available_cam)),
+            text_color="orange",
+            state="readonly",
+        )
+        self.cam_cmbbox.set(f"Camera {self.available_cam[0]}")
+        self.cam_cmbbox.pack(padx=10, side="bottom")
+        self.cam_label.pack(padx=10, side="bottom")
 
         # right frame
         self.canvas = ctk.CTkCanvas(self.cam_frame)


### PR DESCRIPTION
カメラが複数台接続されているときにカメラの切り替えができるようにしました。

Mac でも動作確認済み。iPhone のカメラでも読み込みができそうです。以下、主な変更点です。

- `__init__` メソッドにカメラを認識するコードを追加
  - 最大5台まで認識可能
- `create_widgets` メソッドでカメラ入力選択のプルダウンを作成
  - 左下に配置
- ソース切り替えのメソッド `switch_source` を追加
- カメラ画面の枠線の消去
- Windows で USB 接続しているカメラの認識が遅くなるため、環境変数を設定しました

この機能追加による `gui.py` 以外への変更はありません。ご確認お願いします。