### PR TITLE
重複チェック機能の追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 .env
+kakisute.py

--- a/gui.py
+++ b/gui.py
@@ -212,21 +212,6 @@ class App(ctk.CTk):
                 isbn = value
         return isbn
 
-    def is_duplicated(self, bookdata: dict) -> bool:
-        """
-        Method to upload given book (ISBN) to Notion databse.
-
-        Parameters
-        ----------
-        bookdata: dict
-
-        Return
-        ----------
-        res: bool
-            Whether the scanned book exists in DB
-        """
-        pass
-
     def create_dotenv(self):
         """Method to create .env file initially."""
         dotenv_path = ".env"

--- a/gui.py
+++ b/gui.py
@@ -212,6 +212,21 @@ class App(ctk.CTk):
                 isbn = value
         return isbn
 
+    def is_duplicated(self, bookdata: dict) -> bool:
+        """
+        Method to upload given book (ISBN) to Notion databse.
+
+        Parameters
+        ----------
+        bookdata: dict
+
+        Return
+        ----------
+        res: bool
+            Whether the scanned book exists in DB
+        """
+        pass
+
     def create_dotenv(self):
         """Method to create .env file initially."""
         dotenv_path = ".env"

--- a/gui.py
+++ b/gui.py
@@ -11,7 +11,7 @@ from pyzbar.pyzbar import decode
 
 from src.github import get_latest_tag
 from src.google_books import search_isbn
-from src.notion import add_book_info
+from src.notion import add_book_info, get_isbn_list
 
 # modify these values when creating new release
 VERSION = "v1.2"
@@ -34,7 +34,7 @@ class App(ctk.CTk):
         self.geometry("1024x640")
 
         # --- variables ---
-        self.history = []
+        self.history = get_isbn_list()
         self.cmbbox = None
 
         try:

--- a/gui.py
+++ b/gui.py
@@ -207,7 +207,7 @@ class App(ctk.CTk):
         """
         isbn = None
         for barcode in decode(frame):
-            value = barcode.data.decode("utf-8")
+            value = int(barcode.data.decode("utf-8"))
             if is_valid_ISBN13(value):
                 isbn = value
         return isbn

--- a/src/notion.py
+++ b/src/notion.py
@@ -114,6 +114,14 @@ def add_book_info(
 
 
 def get_isbn_list() -> list[int]:
+    """
+    Method to get the list of ISBN from a database.
+
+    Return
+    ------
+    li_isbn: list[int]
+        List of ISBN in a database.
+    """
     NOTION_API_KEY = get_api_key("NOTION_API_KEY")
 
     url = f"https://api.notion.com/v1/databases/{DATABASE_ID}/query"

--- a/src/notion.py
+++ b/src/notion.py
@@ -113,7 +113,7 @@ def add_book_info(
     return response
 
 
-def get_isbn_list() -> list[int]:
+def get_isbn_list() -> list[int] | None:
     """
     Method to get the list of ISBN from a database.
 
@@ -149,9 +149,11 @@ def get_isbn_list() -> list[int]:
         return li_isbn
     except KeyError as e:
         print(f"Key {e} doesn't exists.")
+        return None
     except BaseException as e:
         print(type(e))
         print(e)
+        return None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
本の重複チェック機能を追加しました。

データベースに登録済みの本が読み込まれた場合、確認ダイアログを表示するようになっています(表示するだけなので、原理上は無限の本が追加可能)。取り急ぎ重複チェック機能を追加した(**重複チェックの概形だけ作った**)、という感じなので重複した本の処理はお任せします。以下、主な変更点です。

- `src/notion.py` に、データベース追加済みの本の ISBN リストを取得する `get_isbn_list` 関数を実装
  - リクエスト1回につき最大で100冊ずつしか取得できないので、全部取得するまで `while` でループさせています
  - また、リクエストも1秒あたりの制限があるのでステータスコードが `200` でなければ0.5秒寝かせるようにしています
    - 500冊ぐらい(これぐらいはありそう)から起動にやや時間がかかりそうです
    - 割と重大な問題だと思っていますが、起動に1分かかるとかではないので我慢の範疇ではあります
- `gui.py` の微修正
  - `self.history` を「一回の起動で読み込んだ本の ISBN のリスト」から「データベースにある本の ISBN のリスト」に変更しました
  - `scan_isbn` の戻り値を `int` に修正しました
    - どうやら `decode` で読み取ったバーコード情報の型は `str` みたいです
    - 関数の型宣言で `int` と言っていたのに、`str` が返ってきていました(沼った)
- `.gitignore` で `kakisute.py` を無視するように変更
  - レスポンスの構造を調べていたときの書き捨てファイルです
  - もし書き捨てファイルを書く場合は、この名前で作ってもらえると勝手に無視されます

`src/notion.py` と `gui.py` と `.gitignore` を変更しました。ご確認ください。